### PR TITLE
Modified body tag in 2nd form to match the 1st

### DIFF
--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -10,6 +10,6 @@
   <%#= label_tag :title %>
   <%#= text_field_tag :title %>
   <%#= label_tag :body %>
-  <%#= text_field_tag :body %>
+  <%#= text_area_tag :body %>
   <%#= submit_tag "Create Article" %>
 <%# end %>


### PR DESCRIPTION
Second form had 'text_field_tag' for the body data, but the first form uses a text area rather than text_field. This makes them match and use the more appropriate text_area option.
